### PR TITLE
Added quote-all option and write-null option. Needed a way to write bare NULL.

### DIFF
--- a/src/main/java/access2csv/Driver.java
+++ b/src/main/java/access2csv/Driver.java
@@ -21,10 +21,11 @@ import com.healthmarketscience.jackcess.*;
 
 public class Driver {
 
-	static int export(Database db, String tableName, Writer csv, boolean withHeader) throws IOException{
+  
+	static int export(Database db, String tableName, Writer csv, boolean withHeader, boolean applyQuotesToAll, String nullText) throws IOException{
 		Table table = db.getTable(tableName);
 		String[] buffer = new String[table.getColumnCount()];
-		CSVWriter writer = new CSVWriter(new BufferedWriter(csv));
+		CSVWriter writer = new CSVWriter(new BufferedWriter(csv), CSVWriter.DEFAULT_SEPARATOR, CSVWriter.DEFAULT_QUOTE_CHARACTER);
 		int rows = 0;
 		try{
 			if (withHeader) {
@@ -32,15 +33,15 @@ public class Driver {
 				for(Column col : table.getColumns()){
 					buffer[x++] = col.getName();
 				}
-				writer.writeNext(buffer);
+				writer.writeNext(buffer, applyQuotesToAll);
 			}
-
+            
 			for(Row row : table){
 				int i = 0;
 				for (Object object : row.values()) {
-					buffer[i++] = object == null ? null : object.toString();
+					buffer[i++] = object == null ? nullText : object.toString();
 				}
-				writer.writeNext(buffer);
+				writer.writeNext(buffer, applyQuotesToAll);
 				rows++;
 			}
 		}finally{
@@ -49,10 +50,10 @@ public class Driver {
 		return rows;
 	}
 
-	static void export(File inputFile, String tableName, File outputDir, String csvPrefix) throws IOException{
+	static void export(File inputFile, String tableName, File outputDir, String csvPrefix, boolean applyQuotesToAll, String nullText) throws IOException{
 		Database db = DatabaseBuilder.open(inputFile);
 		try{
-			export(db, tableName, new FileWriter(new File(outputDir, csvPrefix + tableName + ".csv")), false);
+			export(db, tableName, new FileWriter(new File(outputDir, csvPrefix + tableName + ".csv")), false, applyQuotesToAll, nullText);
 		}finally{
 			db.close();
 		}
@@ -77,7 +78,7 @@ public class Driver {
 
 	}
 
-	static void exportAll(File inputFile, boolean withHeader, File outputDir, String csvPrefix) throws IOException{
+	static void exportAll(File inputFile, boolean withHeader, File outputDir, String csvPrefix, boolean applyQuotesToAll, String nullText) throws IOException{
 		Database db = DatabaseBuilder.open(inputFile);
 		try{
 			for(String tableName : db.getTableNames()){
@@ -87,7 +88,7 @@ public class Driver {
 				try{
 					System.out.println(String.format("Exporting '%s' to %s",
 							tableName, outputFile.toString()));
-					int rows = export(db, tableName, csv, withHeader);
+					int rows = export(db, tableName, csv, withHeader, applyQuotesToAll, nullText);
 					System.out.println(String.format("%d rows exported", rows));
 				}finally{
 					try{
@@ -106,15 +107,25 @@ public class Driver {
 		final OptionParser parser = new OptionParser();
 
 		final OptionSpec<Void> help = parser.acceptsAll(Arrays.asList("help")).forHelp();
-		final OptionSpec<Void> schema = parser.accepts("schema");
-		final OptionSpec<Void> withHeader = parser.accepts("with-header");
+		final OptionSpec<String> schema = parser.accepts("schema").withOptionalArg()
+				.describedAs("The schema is written to standard output.");
+		final OptionSpec<String> withHeader = parser.accepts("with-header").withOptionalArg()
+				.describedAs("When with-header is included, a header line of column names is written to each data file.");
 		final OptionSpec<File> input = parser.accepts("input").withRequiredArg().ofType(File.class).required()
 				.describedAs("The input accdb file.");
 		final OptionSpec<String> table = parser.accepts("table").withRequiredArg().ofType(String.class).describedAs("The table name to export, or all if it is not specified.");
-		final OptionSpec<File> output = parser.accepts("output").withRequiredArg().ofType(File.class).required()
-				.describedAs("The output directory.");
-		final OptionSpec<String> csvPrefix = parser.accepts("csv-prefix").withRequiredArg().ofType(String.class).defaultsTo("").describedAs("A prefix to add to all of the generated CSV file names");
-
+		final OptionSpec<File> output = parser.accepts("output").requiredUnless("schema").withRequiredArg().ofType(File.class)
+				.describedAs("The output directory for data files. This is required for writing data output. This not required for schema output.");
+		final OptionSpec<String> csvPrefix = parser.accepts("csv-prefix").withRequiredArg().ofType(String.class).defaultsTo("").describedAs("A prefix to add to all of the generated CSV file names");    
+		final OptionSpec<Boolean> quoteAll = parser.accepts("quote-all").withOptionalArg().ofType(Boolean.class).defaultsTo(true)
+				.describedAs("Set quote-all to true if all values are to be quoted. " +
+				"Set to false if quotes are only to be applied to values which contain " + 
+				"the separator, secape, quote, or new line characters. The default is true.");
+		final OptionSpec<String> writeNull = parser.accepts("write-null").withOptionalArg().ofType(String.class).defaultsTo("")
+				.describedAs("The text to write when entry is NULL. Defaults to empty output if not specified or if no argument supplied. " +
+				"If quote-all is set to true then the value for write-null is also quoted.");
+   
+    
 		OptionSet options = null;
 
 		try {
@@ -129,25 +140,44 @@ public class Driver {
 			parser.printHelpOn(System.out);
 			return;
 		}
-
+      
 		File inputFile = input.value(options);
 		if(!inputFile.exists()) {
 			throw new FileNotFoundException("Could not find input file: " + inputFile.toString());
 		}
 		
-		File outputDir = output.value(options);
-		if(!outputDir.exists()) {
-			outputDir.mkdirs();
+		File outputDir = null;
+		if (options.has(output)) {
+			outputDir = output.value(options);
+			if(!outputDir.exists()) {
+				outputDir.mkdirs();
+			}	
 		}
 		
-		if(options.has(schema)) {
-			exportAll(inputFile, options.has(withHeader), outputDir, csvPrefix.value(options));
+		boolean applyQuotesToAll = true;
+			if (options.has(quoteAll)) {
+			applyQuotesToAll = quoteAll.value(options);
 		}
-		else if (options.has(table)){
-			export(inputFile, table.value(options), outputDir, csvPrefix.value(options));
+    
+		String nullText = null;
+		if (options.has(writeNull)) {
+			nullText = writeNull.value(options);
+			if ("".equals(nullText)) {        
+				nullText = null;
+			}
 		}
-		else {
-			exportAll(inputFile, false, outputDir, csvPrefix.value(options));
+    
+		if (options.has(schema)) {
+			schema(inputFile);
+		}
+		
+		if (null != outputDir) {
+			if (options.has(table)){
+				export(inputFile, table.value(options), outputDir, csvPrefix.value(options), applyQuotesToAll, nullText);
+			}
+			else {
+				exportAll(inputFile, options.has(withHeader), outputDir, csvPrefix.value(options), applyQuotesToAll, nullText);
+			}	
 		}
 	}
 


### PR DESCRIPTION
- Added quote-all option and write-null option. Needed a way to write out bare NULL without surrounding quotes. 
- If schema is specified then output directory is not required (then data files would not be exported). 
- Added descriptions for with-header and schema options.